### PR TITLE
Fix spelling error in Bazel Hashing Doc

### DIFF
--- a/designs/2018-07-13-repository-hashing.md
+++ b/designs/2018-07-13-repository-hashing.md
@@ -1,4 +1,4 @@
-# Bazel hashing of external direcotry output
+# Bazel hashing of external directory output
 
 ## Background
 


### PR DESCRIPTION
Small nit in title of #7 