### PR TITLE
updated a url to a local repo for design document

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ list.
 
 | Last updated | Title                                                                                                                                                     | Author(s) alias                                                              | Category              |
 | ------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- | --------------------- |
-|   2019-05-02 | [HTTP downloads with Authorization using .netrc](https://github.com/genrym/proposals/blob/http-netrc-auth/designs/2019-05-01-http-auth.md) | [@genrym](https://github.com/genrym) | External Repositories |
+|   2019-05-02 | [HTTP downloads with Authorization using .netrc](designs/2019-05-01-http-auth.md) | [@genrym](https://github.com/genrym) | External Repositories |
 |   2019-04-22 | [Move //tools/build_defs/pkg to rules_pkg](https://docs.google.com/document/d/1GAbAiW0nVbxGlwsdXhFIcn3owlZJkMJiXBt-ttA9z_k/edit)     | [@aiuto](https://github.com/aiuto) | Bazel |
 |   2019-04-16 | [Common Bazel Constraints](https://docs.google.com/document/d/1bqPF7CjHI03xHZmpy8gOE186uNjeU3dGYU8v2t-qiJ8/edit)     | [@gregestren](https://github.com/gregestren) | Configurability |
 |   2019-04-09 | [Experimental Content-Based Output Paths](https://docs.google.com/document/d/17snvmic26-QdGuwVw55Gl0oOufw9sCVuOAvHqGZJFr4/edit) | [@gregestren](https://github.com/gregestren) | Configurability


### PR DESCRIPTION
The link to the design document was to the forked repository.
Updated it to be as relative to the repo.

@aehlig Should I open a discussion in `bazel-dev` about the design?