### PR TITLE
Mark authentication design as approved

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ list.
 
 | Last updated | Title                                                                                                                  | Author(s) alias                                                                    | Category              |
 | ------------ | ------------------------------------------------------------------------------------------------------------------     | ---------------------------------------------------------------------------------- | --------              |
+|   2019-05-27 | [Authentication for `ctx.download`](designs/2019-05-27-auth.md)                                                        | [@aehlig](https://github.com/aehlig)                                               | External Repositories |
 |   2019-05-08 | [Android Native to Starlark Migration](https://docs.google.com/document/d/175BlYH-Z_V_FFGAVP-JA5FowLATRjY_MtOrglxFnfcE/edit)                                                                      | [@timpeut](https://github.com/timpeut)             | Android |
 |   2019-04-12 | [Propagate tags from the targets to actions](https://docs.google.com/document/d/1X2GtuuNT6UqYYOK5lJWQEdPjAgsbdB3nFjjmjso-XHo/edit?usp=sharing)| [@ishikhman](https://github.com/ishikhman)              | Bazel, Starlark       |
 |   2019-03-22 | [Execution Transitions](designs/2019-02-12-execution-transitions.md) | [@katre](https://github.com/katre) | Configurability |
@@ -80,7 +81,6 @@ list.
 
 | Last updated | Title                                                                                                                                                     | Author(s) alias                                                              | Category              |
 | ------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- | --------------------- |
-|   2019-05-27 | [Authentication for `ctx.download`](designs/2019-05-27-auth.md)                                                                                           | [@aehlig](https://github.com/aehlig)                                         | External Repositories |
 |   2019-05-02 | [HTTP downloads with Authorization using .netrc](designs/2019-05-01-http-auth.md) | [@genrym](https://github.com/genrym) | External Repositories |
 |   2019-04-22 | [Move //tools/build_defs/pkg to rules_pkg](https://docs.google.com/document/d/1GAbAiW0nVbxGlwsdXhFIcn3owlZJkMJiXBt-ttA9z_k/edit)     | [@aiuto](https://github.com/aiuto) | Bazel |
 |   2019-04-16 | [Common Bazel Constraints](https://docs.google.com/document/d/1bqPF7CjHI03xHZmpy8gOE186uNjeU3dGYU8v2t-qiJ8/edit)     | [@gregestren](https://github.com/gregestren) | Configurability |

--- a/designs/2019-05-27-auth.md
+++ b/designs/2019-05-27-auth.md
@@ -1,7 +1,7 @@
 ---
 created: 2019-05-27
 last updated: 2019-05-27
-status: To be reviewed
+status: approved
 title: Authentication in downloads
 authors:
   - aehlig
@@ -76,8 +76,12 @@ Of course, the authentication dictionary would not be committed into the
 workspace; it would only be constructed by the rule in memory from some
 form of credential store, e.g., a
 [`.netrc`](https://www.gnu.org/software/inetutils/manual/html_node/The-_002enetrc-file.html)
-file. So simplify that use case, a Starlark function will be provided to compute
+file. To simplify that use case, a Starlark function will be provided to compute
 that dictonary from a list of URLs and a path to a `.netrc` file.
+Moreover, the version of `http_archive` (and related rules) that ships embedded
+in bazel will use functions to honor a `.netrc` file in the user's home
+direcotry, unless explicitly told to user other (including no) credentials by
+an explict `auth` dict passed as argument.
 
 # Considerations
 


### PR DESCRIPTION
...as was decided in the Starlark meeting at June 6, 2019.
Also add a clarifying statement that http_archive will by
default honor a `.netrc` file even though this will not
be part of the build API, but instead an implementation
detail of the corresponding Starlark rule.