### PR TITLE
Mark authentication design as implemented

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ list.
 
 | Last updated | Title                                                                                                                                      | Author(s) alias                                  | Category              |
 | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------ | --------              |
+|   2019-05-27 | [Authentication for `ctx.download`](designs/2019-05-27-auth.md)                                                        | [@aehlig](https://github.com/aehlig)                                               | External Repositories |
 |   2019-04-29 | [Forcing non-cache-hits in the repository cache](designs/2019-04-29-cache.md)                                                              | [@aehlig](https://github.com/aehlig)             | External Repositories |
 |   2019-04-05 | [Handling download failures](designs/2019-03-21-download-failures.md)                                                                      | [@aehlig](https://github.com/aehlig)             | External Repositories |
 |   2018-12-14 | [Versioned Documentation](https://docs.google.com/document/d/1MNe8IWz7td4_Yr3r43YL-hrFSmQvFutum-av-Sny56s/edit#)                           | [@jin](https://github.com/jin)                   | Documentation         |

--- a/designs/2019-05-27-auth.md
+++ b/designs/2019-05-27-auth.md
@@ -1,7 +1,7 @@
 ---
 created: 2019-05-27
 last updated: 2019-05-27
-status: To be reviewed
+status: approved
 title: Authentication in downloads
 authors:
   - aehlig
@@ -76,8 +76,12 @@ Of course, the authentication dictionary would not be committed into the
 workspace; it would only be constructed by the rule in memory from some
 form of credential store, e.g., a
 [`.netrc`](https://www.gnu.org/software/inetutils/manual/html_node/The-_002enetrc-file.html)
-file. So simplify that use case, a Starlark function will be provided to compute
+file. To simplify that use case, a Starlark function will be provided to compute
 that dictonary from a list of URLs and a path to a `.netrc` file.
+Moreover, the version of `http_archive` (and related rules) that ships embedded
+in bazel will use functions to honor a `.netrc` file in the user's home
+direcotry, unless explicitly told to user other (including no) credentials by
+an explict `auth` dict passed as argument.
 
 # Considerations
 


### PR DESCRIPTION
It was approved in the Starlark meeting at June 6, 2019
and the implementation completed in 26e3396cb341e173b4be5c780cafac3ec386df5.

Also add a clarifying statement that http_archive will by
default honor a `.netrc` file even though this will not
be part of the build API, but instead an implementation
detail of the corresponding Starlark rule.