### PR TITLE
file visibility: extend the example section

### DIFF
--- a/designs/2019-10-24-file-visibility.md
+++ b/designs/2019-10-24-file-visibility.md
@@ -1,6 +1,6 @@
 ---
 created: 2019-10-24
-last updated: 2019-10-24
+last updated: 2019-10-30
 status: To be reviewed
 reviewers:
   - laurentlb
@@ -53,6 +53,27 @@ intention might have been to only expose the application and its
 manual page. As a result of this, every package can depend on,
 e.g., the file `util.c` directly, making it hard for the package
 to evolve this internal interface without breaking other packages.
+
+It is the usage of a file that exposes it with the `default_visibility`.
+A file `testtool.c` never used in the `BUILD` file of its package
+cannot be used by other packages either. But any use, even in a
+private target exposes it. E.g., adding the following to said `BUILD`
+file will still publicly expose the `testtool.c` even for non-test targets
+(as opposed to the private test-only binary generated from that file).
+
+```
+cc_binary(
+  name = "testtool",
+  srcs = ["testtool.c"],
+  testonly = True,
+  visibility = ["//visibility:private"],
+)
+```
+
+This semantics, that a use of a file in a private target exposes that
+very file with the default visibility is often considered counterintuitive
+and has led to unintended dependencies in the past.
+
 
 # Proposal
 


### PR DESCRIPTION
...highlighting the aspect that exposure with default
visibility happens independent of the visibility of the
target using the source file.