### PR TITLE
Add "Keepalived remote execution"

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ list.
 |   2021-02-15 | [External C/C++ libraries rules](https://docs.google.com/document/d/1Gv452Vtki8edo_Dj9VTNJt5DA_lKTcSMwrwjJOkLaoU/edit?usp=sharing) | [@ichern](https://github.com/irengrig)                                         | Bazel                 |
 |   2021-02-15 | [Bazel Runfiles Libraries](https://docs.google.com/document/d/e/2PACX-1vSDIrFnFvEYhKsCMdGdD40wZRBX3m3aZ5HhVj4CtHPmiXKDCxioTUbYsDydjKtFDAzER5eg7OjJWs3V/pub) | [@laszlocsomor](https://github.com/laszlocsomor) | Bazel                 |
 |   2021-02-15 | [Name resolution](designs/2018-06-18-name-resolution.md)                                                                       | [@laurentlb](https://github.com/laurentlb)                                     | Starlark               |
+|   2020-10-28 | [Keepalived remote execution](https://docs.google.com/document/d/1NgDPsCIwprDdqC1zj0qQrh5KGK2hQTSTux1DAvi4rSc/edit) | [@coeuvre](https://github.com/coeuvre) | Remote Execution |
 |   2020-09-30 | [Toolchain Transition Migration](designs/2020-02-07-toolchain-transition-migration.md)                                          | [@katre](https://github.com/katre)       | Configurability |
 |   2020-09-30 | [Toolchain Transitions](designs/2019-02-12-toolchain-transitions.md) | [@katre](https://github.com/katre) | Configurability |
 |   2020-09-30 | [Passing Toolchain Context across Dependencies](designs/2020-05-13-toolchain-context-dependencies.md) | [@katre](https://github.com/katre) | Configurability |


### PR DESCRIPTION
Make remote execution calls keepalived to avoid Bazel hanging indefinitely due to network issues. This could be one of the reasons causing Bazel to hang forever. The hanging issue is reported at https://github.com/bazelbuild/bazel/issues/11782.