### PR TITLE
Move SIG proposal to approved state

### DIFF
--- a/designs/2021-08-10-rules-authors-sig.md
+++ b/designs/2021-08-10-rules-authors-sig.md
@@ -1,9 +1,9 @@
 ---
 created: 2021-08-10
 last updated: 2021-08-19
-status: To be reviewed
+status: Approved
 reviewers:
-  - philwo [?]
+  - philwo
   - sventiffe
   - hicksjoseph
 title: Rules Authors SIG


### PR DESCRIPTION
Per the process outlined on the repo, one week after the original proposal was merged here and discussion on the bazel-dev mailing list, the "Reviewers approve proposal" and it goes to "Approved".

What is remaining for the reviewers to approve the proposal? The SIG has already had a preliminary meeting including some Googler participants, and is starting to form the governance docs to start doing useful work.