### PR TITLE
Add "Standard exec configurations" to review

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ stateDiagram-v2
 
 | Last updated | Title                                                                                                                                                     | Author(s) alias                                                              | Category              |
 | ------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- | --------------------- |
+|   2023-08-08 | [Standard exec configurations](https://docs.google.com/document/d/1fyeR2eYP7wlN36btaEV2gjZOYW_PANpJI-XNVErZXwQ/edit) | [@gregestren](https://github.com/gregestren) | Configurability |
 |   2023-08-08 | [`bazel mod fix`](https://docs.google.com/document/d/13LbK_1WhA4la0eH7yISjnMvXs2cKFXD-adKPu0i0RK0/edit) | [@fmeum](https://github.com/fmeum) | External dependencies |
 |   2023-08-08 | [Inheritance of Target Incompatibility](https://docs.google.com/document/d/127pgkR610qaz1k3-OVgt3tbEeMKAm_jFNeRQcUc99d0/edit) | [@fmeum](https://github.com/fmeum) | Platforms, Configurability |
 |   2023-08-01 | [Bazel Proto Rules](https://docs.google.com/document/d/1l5JrFOxjU1USWXoc_KeBIjBoae5nkaL5AqhNiHLYeyI/edit?usp=sharing) | [@comius](https://github.com/comius) | Proto Rules |


### PR DESCRIPTION
@katre  already reviewed this, and I've started implementing. But we didn't share this publicly. Doing so now to update the community and solicit wider feedback.

Note this doc is generic in its ideas but  focused on Google's repo as an initial test of "cleaning up a repo". 

Other orgs would need to consider this independently based on their own patterns. Some of the cleanup can't generalize to other orgs because of that.