### PR TITLE
Fix some YAML errors in proposals

### DIFF
--- a/designs/2022-06-07-bazel-credential-helpers.md
+++ b/designs/2022-06-07-bazel-credential-helpers.md
@@ -3,9 +3,9 @@ created: 2022-06-07
 last updated: 2023-06-13
 status: Implemented
 reviewers:
-  - @tjgq
-  - @wyverald
-  - @bergsieker
+  - tjgq
+  - wyverald
+  - bergsieker
 title: Credential Helpers for Bazel
 authors:
   - Yannic

--- a/designs/2022-07-21-locating-runfiles-with-bzlmod.md
+++ b/designs/2022-07-21-locating-runfiles-with-bzlmod.md
@@ -1,15 +1,14 @@
-
 ---
 created: 2022-07-21
 last updated: 2022-09-07
 status: Approved
 reviewers:
-  - @Wyverald
-  - @oquenchil
-  - @phst
+  - wyverald
+  - oquenchil
+  - phst
 title: Locating runfiles with Bzlmod
 authors:
-  - @fmeum
+  - fmeum
 ---
 
 # Abstract

--- a/designs/2022-08-03-platforms-on-targets.md
+++ b/designs/2022-08-03-platforms-on-targets.md
@@ -2,9 +2,11 @@
 created: 2022-08-03
 last updated: 2022-11-16
 status: Dropped
-reviewers: @gregestren
+reviewers:
+  - gregestren
 title: Platforms on Targets
-authors: katre
+authors:
+  - katre
 discussion thread: https://groups.google.com/g/bazel-dev/c/QK7CI__ReDM
 ---
 

--- a/designs/2022-10-17-dependency-adapter.md
+++ b/designs/2022-10-17-dependency-adapter.md
@@ -2,9 +2,10 @@
 created: 2022-10-17
 last updated: 2022-10-17
 status: Draft
-reviewers: TBD
+reviewers:
 title: Dependency adapters for virtual targets
-authors: `@vdye`
+authors:
+  - vdye
 ---
 
 # Abstract

--- a/designs/2023-06-08-platform-based-flags.md
+++ b/designs/2023-06-08-platform-based-flags.md
@@ -2,9 +2,12 @@
 created: 2023-06-08
 last updated: 2023-08-14
 status: Approved
-reviewers: gregestren, sdtwigg
+reviewers:
+  - gregestren
+  - sdtwigg
 title: Platform-based Flags
-authors: katre
+authors:
+  - katre
 discussion thread: https://github.com/bazelbuild/bazel/discussions/18672
 ---
 

--- a/designs/2023-06-08-standard-platform-transitions.md
+++ b/designs/2023-06-08-standard-platform-transitions.md
@@ -2,9 +2,11 @@
 created: 2023-06-08
 last updated: 2023-08-08
 status: Approved
-reviewers: gregestren
+reviewers:
+  - gregestren
 title: Standard Platform Transitions
-authors: katre
+authors:
+  - katre
 discussion thread: https://github.com/bazelbuild/bazel/discussions/18628
 ---
 


### PR DESCRIPTION
In some of the proposals, the header with the metadata on the proposal does not render correctly on GitHub. Example:

```
Error in user YAML: (<unknown>): found character that cannot start any token while scanning for the next token at line 5 column 5
```

This seems to be caused by entries starting with an `@` symbol. This change fixes that.