### PR TITLE
`--remote_local_fallback` Respects Strategy Declarations

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ stateDiagram-v2
 
 | Last updated | Title                                                                                                                                                     | Author(s) alias                                                              | Category              |
 | ------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- | --------------------- |
+|   2023-12-12 | [`--remote_local_fallback` Respects Strategy Declarations](designs/2023-12-07-remote-local-fallback-respects-declarations.md) | [@Silic0nS0ldier](https://github.com/Silic0nS0ldier) | Configurability, Execution Strategy |
 |   2023-12-07 | [Execution Platform Scoped Spawn Strategies](designs/2023-06-04-exec-platform-scoped-spawn-strategies.md) | [@Silic0nS0ldier](https://github.com/Silic0nS0ldier) | Configurability, Execution Strategy |
 |   2023-12-5 | [Offline & Vendor Modes](https://docs.google.com/document/d/1P9WwRvpGLi9Tw-AKN7dZ2AeRmfVsl_-lH-N9g3UkVMI) | [@salmasamy](https://github.com/SalmaSamy) | Bazel, External Repositories |
 |   2023-11-09 | [Avoiding accidental secret leaks in the BEP](https://docs.google.com/document/d/1-ou6dLV9xsjSSrKf3uJdZKZo-BUlTqbf0OAmKoe_W1s/edit) | [@jmmv](https://github.com/jmmv) | Core |
@@ -70,7 +71,6 @@ stateDiagram-v2
 
 | Last updated | Title                                                                                                                           | Author(s) alias                          | Category |
 |--------------|---------------------------------------------------------------------------------------------------------------------------------|------------------------------------------|----------|
-|   2023-12-08 | [`--remote_local_fallback` Respects Strategy Declarations](designs/2023-12-07-remote-local-fallback-respects-declarations.md) | [@Silic0nS0ldier](https://github.com/Silic0nS0ldier) | Configurability, Execution Strategy |
 | 2023-10-25   | [Faster aspects: pruning on the way down](https://docs.google.com/document/d/1Md4BX2v-VMV-qNmc-wdeImTCdBK9BRF6YNktmOBVVVY/edit)                                | [@aiuto](https://github.com/aiuto)          |
 | 2023-10-25   | [Better SBOMS: annotated rule attributes](https://docs.google.com/document/d/1ReiTFz5N98D9bGPgL45ziQnGT8xJAunug9JJ89gZsm8/edit)                                | [@aiuto](https://github.com/aiuto)          |
 |   2023-10-23 | [Incremental builds with small memory footprint](https://docs.google.com/document/d/1k1Ajt283hf0eGYDcE5QQbfrXYTQB04RPWSHeF9sd9aw/edit?usp=sharing) | [@lberki](https://github.com/lberki) | Core |

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ stateDiagram-v2
 
 | Last updated | Title                                                                                                                           | Author(s) alias                          | Category |
 |--------------|---------------------------------------------------------------------------------------------------------------------------------|------------------------------------------|----------|
+|   2023-12-07 | [`--remote_local_fallback` Respects Strategy Declarations](designs/2023-12-07-remote-local-fallback-respects-declarations.md) | [@Silic0nS0ldier](https://github.com/Silic0nS0ldier) | Configurability, Execution Strategy |
 | 2023-10-25   | [Faster aspects: pruning on the way down](https://docs.google.com/document/d/1Md4BX2v-VMV-qNmc-wdeImTCdBK9BRF6YNktmOBVVVY/edit)                                | [@aiuto](https://github.com/aiuto)          |
 | 2023-10-25   | [Better SBOMS: annotated rule attributes](https://docs.google.com/document/d/1ReiTFz5N98D9bGPgL45ziQnGT8xJAunug9JJ89gZsm8/edit)                                | [@aiuto](https://github.com/aiuto)          |
 |   2023-10-23 | [Incremental builds with small memory footprint](https://docs.google.com/document/d/1k1Ajt283hf0eGYDcE5QQbfrXYTQB04RPWSHeF9sd9aw/edit?usp=sharing) | [@lberki](https://github.com/lberki) | Core |

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ stateDiagram-v2
 
 | Last updated | Title                                                                                                                           | Author(s) alias                          | Category |
 |--------------|---------------------------------------------------------------------------------------------------------------------------------|------------------------------------------|----------|
-|   2023-12-07 | [`--remote_local_fallback` Respects Strategy Declarations](designs/2023-12-07-remote-local-fallback-respects-declarations.md) | [@Silic0nS0ldier](https://github.com/Silic0nS0ldier) | Configurability, Execution Strategy |
+|   2023-12-08 | [`--remote_local_fallback` Respects Strategy Declarations](designs/2023-12-07-remote-local-fallback-respects-declarations.md) | [@Silic0nS0ldier](https://github.com/Silic0nS0ldier) | Configurability, Execution Strategy |
 | 2023-10-25   | [Faster aspects: pruning on the way down](https://docs.google.com/document/d/1Md4BX2v-VMV-qNmc-wdeImTCdBK9BRF6YNktmOBVVVY/edit)                                | [@aiuto](https://github.com/aiuto)          |
 | 2023-10-25   | [Better SBOMS: annotated rule attributes](https://docs.google.com/document/d/1ReiTFz5N98D9bGPgL45ziQnGT8xJAunug9JJ89gZsm8/edit)                                | [@aiuto](https://github.com/aiuto)          |
 |   2023-10-23 | [Incremental builds with small memory footprint](https://docs.google.com/document/d/1k1Ajt283hf0eGYDcE5QQbfrXYTQB04RPWSHeF9sd9aw/edit?usp=sharing) | [@lberki](https://github.com/lberki) | Core |

--- a/designs/2023-12-07-remote-local-fallback-respects-declarations.md
+++ b/designs/2023-12-07-remote-local-fallback-respects-declarations.md
@@ -1,6 +1,6 @@
 ---
 created: 2023-12-07
-last updated: 2023-12-07
+last updated: 2023-12-08
 status: Draft
 reviewers:
   - TBD
@@ -12,7 +12,7 @@ authors:
 # Abstract
 
 The flag `--remote_local_fallback` makes it possible for remotely executed action spawns that fail to fallback to the `local` spawn strategy.
-This proposal seeks to treat spawn retries behave identically to actions tagged with `no-remote`.
+This proposal seeks to treat spawn retries identically to actions tagged with `no-remote`.
 
 # Background
 
@@ -25,7 +25,7 @@ e.g.
 build --strategy=Foo=remote
 ```
 
-Requiring that an action be only spawned locally may reflect a technical limitation.
+Requiring that an action be only spawned remotely may reflect a technical limitation.
 Such as the remote offering a Windows environment while Bazel itself is running on a macOS machine.
 The Windows binaries cannot be reasonably expected to work on macOS, and compatibility layers to support such a scenario are unlikely to provide identical behaviour.
 
@@ -40,11 +40,13 @@ Even in a context where remote and local environments are identical, `local` may
 
 # Proposal
 
-A new flag `--incompatible_strict_remote_local_fallback` will be introduced which when flipped makes `--remote_local_fallback` rerun spawn strategy with `remote` ignored.
+A new flag `--incompatible_strict_remote_local_fallback` will be introduced which when flipped makes `--remote_local_fallback` rerun spawn strategy selection with `remote` ignored.
 
 This means;
 * All registered strategies along with their filters are considered (`--spawn_strategy`, `--strategy`, `--strategy_regexp`, etc).
 * If a `remote` spawned action has no local fallback, no attempt to spawn locally is made and the build fails.
+
+To avoid confusion, the `--remote_local_fallback_strategy` flag (currently marked as a deprecated no-op, ([#7480](https://github.com/bazelbuild/bazel/issues/7480))) will be removed.
 
 # Backward-compatibility
 

--- a/designs/2023-12-07-remote-local-fallback-respects-declarations.md
+++ b/designs/2023-12-07-remote-local-fallback-respects-declarations.md
@@ -1,9 +1,9 @@
 ---
 created: 2023-12-07
-last updated: 2023-12-08
-status: Draft
+last updated: 2023-12-12
+status: Under Review
 reviewers:
-  - TBD
+  - tigq
 title: `--remote_local_fallback` Respects Strategy Declarations
 authors:
   - Silic0nS0ldier
@@ -45,8 +45,8 @@ A new flag `--incompatible_strict_remote_local_fallback` will be introduced whic
 This means;
 * All registered strategies along with their filters are considered (`--spawn_strategy`, `--strategy`, `--strategy_regexp`, etc).
 * If a `remote` spawned action has no local fallback, no attempt to spawn locally is made and the build fails.
-
-To avoid confusion, the `--remote_local_fallback_strategy` flag (currently marked as a deprecated no-op, ([#7480](https://github.com/bazelbuild/bazel/issues/7480))) will be removed.
+* The `--remote_local_fallback_strategy` flag will have no effect.
+  Note that it is incorrectly documentated as a no-op in Bazel 7.0.0 (see [#15519 (comment)](https://github.com/bazelbuild/bazel/issues/15519#issuecomment-1841940599)).
 
 # Backward-compatibility
 

--- a/designs/2023-12-07-remote-local-fallback-respects-declarations.md
+++ b/designs/2023-12-07-remote-local-fallback-respects-declarations.md
@@ -1,0 +1,51 @@
+---
+created: 2023-12-07
+last updated: 2023-12-07
+status: Draft
+reviewers:
+  - TBD
+title: `--remote_local_fallback` Respects Strategy Declarations
+authors:
+  - Silic0nS0ldier
+---
+
+# Abstract
+
+The flag `--remote_local_fallback` makes it possible for remotely executed action spawns that fail to fallback to the `local` spawn strategy.
+This proposal seeks to treat spawn retries behave identically to actions tagged with `no-remote`.
+
+# Background
+
+Falling back to the local environment is not always safe, and may be contrary to spawn strategy configuration.
+
+e.g.
+
+```ini
+# Denotes actions with the mnemonic `FOO` must always be spawn with the `remote` strategy
+build --strategy=Foo=remote
+```
+
+Requiring that an action be only spawned locally may reflect a technical limitation.
+Such as the remote offering a Windows environment while Bazel itself is running on a macOS machine.
+The Windows binaries cannot be reasonably expected to work on macOS, and compatibility layers to support such a scenario are unlikely to provide identical behaviour.
+
+Even in a context where remote and local environments are identical, `local` may not represent the optimal spawn strategy.
+* `worker` may offer better performance, especially if several remotable actions fail (e.g. connectivity loss).
+* `sandboxed` may provide an environment closer to that of the remote.
+
+## Related Issues
+
+* [remote: remove local fallback for remote execution](https://github.com/bazelbuild/bazel/issues/7202)
+* [Make --remote_local_fallback honor --spawn_strategy](https://github.com/bazelbuild/bazel/issues/15519)
+
+# Proposal
+
+A new flag `--incompatible_strict_remote_local_fallback` will be introduced which when flipped makes `--remote_local_fallback` rerun spawn strategy with `remote` ignored.
+
+This means;
+* All registered strategies along with their filters are considered (`--spawn_strategy`, `--strategy`, `--strategy_regexp`, etc).
+* If a `remote` spawned action has no local fallback, no attempt to spawn locally is made and the build fails.
+
+# Backward-compatibility
+
+Current behaviour is counterproductive, so the expectation is that flag guarded behaviour would become the default in the next major version of Bazel.


### PR DESCRIPTION
This is a follow up to #359 proposing to make `--remote_local_fallback` fallback to a freshly picked non-remote spawn strategy (if there are candidates left) rather than `local`.

## Related Issues

- https://github.com/bazelbuild/bazel/issues/7202
- https://github.com/bazelbuild/bazel/issues/15519