### PR TITLE
More feedback from review of exec platform scoped spawn strategies proposal

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ stateDiagram-v2
 
 | Last updated | Title                                                                                                                                                     | Author(s) alias                                                              | Category              |
 | ------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- | --------------------- |
+|   2024-01-25 | [Execution Platform Scoped Spawn Strategies](designs/2023-06-04-exec-platform-scoped-spawn-strategies.md) | [@Silic0nS0ldier](https://github.com/Silic0nS0ldier) | Configurability, Execution Strategy |
 |   2024-01-22 | [Garbage collection for the disk cache](https://docs.google.com/document/d/16aGm4u9EgW199M1WjjbVbVCJSfa8RApWPcKnZYnVbrI) | [@tjgq](https://github.com/tjgq) | Performance |
 |   2024-01-18 | [Bazel Remote Output Service](https://docs.google.com/document/d/1W6Tqq8cndssnDI0yzFSoj95oezRKcIhU57nwLHaN1qk/edit) | [@coeuvre](https://github.com/coeuvre) | Remote Execution |
-|   2023-12-21 | [Execution Platform Scoped Spawn Strategies](designs/2023-06-04-exec-platform-scoped-spawn-strategies.md) | [@Silic0nS0ldier](https://github.com/Silic0nS0ldier) | Configurability, Execution Strategy |
 |   2023-12-12 | [`--remote_local_fallback` Respects Strategy Declarations](designs/2023-12-07-remote-local-fallback-respects-declarations.md) | [@Silic0nS0ldier](https://github.com/Silic0nS0ldier) | Configurability, Execution Strategy |
 |   2023-12-5 | [Offline & Vendor Modes](https://docs.google.com/document/d/1P9WwRvpGLi9Tw-AKN7dZ2AeRmfVsl_-lH-N9g3UkVMI) | [@salmasamy](https://github.com/SalmaSamy) | Bazel, External Repositories |
 |   2023-11-09 | [Avoiding accidental secret leaks in the BEP](https://docs.google.com/document/d/1-ou6dLV9xsjSSrKf3uJdZKZo-BUlTqbf0OAmKoe_W1s/edit) | [@jmmv](https://github.com/jmmv) | Core |

--- a/designs/2023-06-04-exec-platform-scoped-spawn-strategies.md
+++ b/designs/2023-06-04-exec-platform-scoped-spawn-strategies.md
@@ -54,7 +54,7 @@ foo_binary(
 # //.bazelrc
 build --spawn_strategy=remote
 build --host_platform=//:darwin_amd64
-build --extra_exec_platforms=//:linux_amd64,//:win_amd64
+build --extra_execution_platforms=//:linux_amd64,//:win_amd64
 # + extras required for remote execution
 ```
 
@@ -84,9 +84,9 @@ Make it possible to declare spawn strategies supported by an execution platform.
 ```ini
 # //.bazelrc
 # Allow usage of "worker", "sandboxed" or "local" when exec platform is "//:darwin_arm64"
-build --allowed_strategies_exec_platform//:darwin_arm64=worker,sandboxed,local
+build --allowed_strategies_execution_platform//:darwin_arm64=worker,sandboxed,local
 # Allow usage of "remote" when exec platform is "//:linux_amd64"
-build --allowed_strategies_exec_platform=//:linux_amd64=remote
+build --allowed_strategies_execution_platform=//:linux_amd64=remote
 ```
 
 The goal behind this proposal is to address the capability gap (picking appropriate spawn strategies for execution platforms) while work on a more comprehensive solution continues ([#19904](https://github.com/bazelbuild/bazel/issues/19904)).

--- a/designs/2023-06-04-exec-platform-scoped-spawn-strategies.md
+++ b/designs/2023-06-04-exec-platform-scoped-spawn-strategies.md
@@ -1,6 +1,6 @@
 ---
 created: 2023-06-04
-last updated: 2024-01-26
+last updated: 2024-02-10
 status: Under Review
 reviewers:
   - katre
@@ -84,9 +84,9 @@ Make it possible to declare spawn strategies supported by an execution platform.
 ```ini
 # //.bazelrc
 # Allow usage of "worker", "sandboxed" or "local" when exec platform is "//:darwin_arm64"
-build --allowed_strategies_execution_platform//:darwin_arm64=worker,sandboxed,local
+build --allowed_strategies_by_exec_platform//:darwin_arm64=worker,sandboxed,local
 # Allow usage of "remote" when exec platform is "//:linux_amd64"
-build --allowed_strategies_execution_platform=//:linux_amd64=remote
+build --allowed_strategies_by_exec_platform=//:linux_amd64=remote
 ```
 
 The goal behind this proposal is to address the capability gap (picking appropriate spawn strategies for execution platforms) while work on a more comprehensive solution continues ([#19904](https://github.com/bazelbuild/bazel/issues/19904)).

--- a/designs/2023-06-04-exec-platform-scoped-spawn-strategies.md
+++ b/designs/2023-06-04-exec-platform-scoped-spawn-strategies.md
@@ -1,6 +1,6 @@
 ---
 created: 2023-06-04
-last updated: 2023-12-21
+last updated: 2024-01-25
 status: Under Review
 reviewers:
   - katre
@@ -38,24 +38,15 @@ For example;
 ```starlark
 # //BUILD.bazel
 
-# Unsupported on remote
-platform(
-    name = "darwin_arm64",
-    ...
-)
+# Valid as execution platform on host only
+platform(name = "darwin_arm64", ...)
 
-platform(
-    name = "linux_amd64",
-    ...
-)
-
-platform(
-    name = "win_amd64",
-    ...
-)
+# Valid as exeution platform on remote only
+platform(name = "linux_amd64", ...)
+platform(name = "win_amd64", ...)
 
 foo_binary(
-    name = "foo-bin"
+    name = "foo-bin",
 )
 ```
 
@@ -63,8 +54,8 @@ foo_binary(
 # //.bazelrc
 build --spawn_strategy=remote
 build --host_platform=//:darwin_amd64
-build --extra_exec_platforms=...
-# extra bits for remote connection
+build --extra_exec_platforms=//:linux_amd64,//:win_amd64
+# + extras required for remote execution
 ```
 
 ```sh
@@ -92,10 +83,10 @@ Make it possible to declare spawn strategies supported by an execution platform.
 
 ```ini
 # //.bazelrc
-# When the exec platform is "//:darwin_arm64" only allow one of "worker,sandboxed,local"
-build --execution_platform_supported_strategies=//:darwin_arm64=worker,sandboxed,local
-# For "//:linux_amd64" only allow "remote"
-build --execution_platform_supported_strategies=//:linux_amd64=remote
+# Allow usage of "worker", "sandboxed" or "local" when exec platform is "//:darwin_arm64"
+build --allowed_strategies_exec_platform//:darwin_arm64=worker,sandboxed,local
+# Allow usage of "remote" when exec platform is "//:linux_amd64"
+build --allowed_strategies_exec_platform=//:linux_amd64=remote
 ```
 
 The goal behind this proposal is to address the capability gap (picking appropriate spawn strategies for execution platforms) while work on a more comprehensive solution continues ([#19904](https://github.com/bazelbuild/bazel/issues/19904)).
@@ -112,7 +103,7 @@ This does not seek to solve;
 ## Flags
 
 The likihood of misconfiguration can be reduced with;
-- `--[no]require_platform_scoped_strategies` to make inclusion of platforms in spawn strategy flags mandatory.
+- `--[no]strict_exec_platform_strategies` to require that every exec platform (including host) have a strategies allowlist (checked after workspace evaluation).
 
 ## Dynamic Execution
 
@@ -122,7 +113,7 @@ Strategies supplied for the `dynamic` meta-strategy via `--dynamic_remote_strate
 
 ### Actions Lacking Execution Platform
 
-It is theoretically possible for an which relies on spawn strategies (`ctx.actions.run` and `ctx.actions.run_shell`) to lack an execution platform, though almost certainly a bug (`exec_properties` wouldn't be included for `remote` spawns).
+It is theoretically possible for an action which relies on spawn strategies (`ctx.actions.run` and `ctx.actions.run_shell`) to lack an execution platform, though almost certainly a bug (`exec_properties` wouldn't be included for `remote` spawns).
 
 An [investigation](https://github.com/bazelbuild/bazel/issues/20505#issuecomment-1856144402) by [`@katre`](https://github.com/katre) indicates that at present only file write actions (`ctx.actions.write`, `ctx.actions.symlink`, `ctx.actions.expand_template`) lack a platform (their platform is inherently always that of the host), however there are no guards to enforce this.
 
@@ -158,3 +149,21 @@ It is also worth considering the current status of the `platform(...)` abstracti
 2. An opaque collection of properties for remote execution. (`exec_properties`)
 
 (1) has value for all target and execution platform use cases, while (2) is limited to a subset of execution platform use cases (configuring remote execution services). It is probable the `exec_properties` attribute will be relocated in a future redesign of the spawn strategy subsystem.
+
+## Extending Existing Spawn Strategy Flags
+
+The initial version of this proposal sought to extend the existing spawn strategy flags.
+
+e.g.
+
+```ini
+# //.bazelrc
+# When the exec platform is "//:darwin_arm64" use one of "worker,sandboxed,local" by default
+build --spawn_strategy=//:darwin_arm64=worker,sandboxed,local
+# For actions with the "FOO" mnemonic and exec platform "//:darwin_arm64" use "local"
+build --strategy=FOO=//:darwin_arm64=local
+# For actions with a description which matches regex "//foo.*\.cc" and exec platform "//:darwin_arm64" use "local"
+build --strategy_regexp=//foo.*\.cc=//:darwin_arm64=local
+```
+
+This was rejected as the existing interface was already complicated and the change would increase complexity. As the existing interface is already complex, there is also a risk the required changes would lead to a compatibility break (a-la Hyrum's Law).

--- a/designs/2023-06-04-exec-platform-scoped-spawn-strategies.md
+++ b/designs/2023-06-04-exec-platform-scoped-spawn-strategies.md
@@ -102,8 +102,8 @@ This does not seek to solve;
 
 ## Flags
 
-The likihood of misconfiguration can be reduced with;
-- `--[no]strict_exec_platform_strategies` to require that every exec platform (including host) have a strategies allowlist (checked after workspace evaluation).
+The likelihood of misconfiguration can be reduced with;
+- `--[no]require_platform_scoped_strategies` to require that every exec platform (including host) have a strategies allowlist (checked after workspace evaluation).
 
 ## Dynamic Execution
 


### PR DESCRIPTION
Main changes of significance here is the renaming of 1 flag.

`--allowed_strategies_execution_platform` to specify an allowlist for an exec platform
- A _little_ less confusing to read than `--execution_platform_supported_strategies`.
- Read as "allowed strategies for execution platform".

The strictness flag `--require_platform_scoped_strategies` seems a little off but I'm unable to think up a better option at this point in time. I understand these proposals are not gospel so if I (or anyone else) comes up with better names, I'll put them forward with the implementation.