### PR TITLE
Mark "Selectively Enabling Execution Platforms" as approved

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ stateDiagram-v2
 | Last updated | Title                                                                                                                                                     | Author(s) alias                                                              | Category              |
 | ------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- | --------------------- |
 |   2024-05-06 | [Latent Dependencies](https://docs.google.com/document/d/1BLgnPvWqI1hfUh-rXD6Gw6QqqjwAyJuqhjuAL0t6lBw/edit) | [@lberki](https://github.com/lberki) | Build Language |
-|   2024-04-29 | [Selectively Enabling Execution Platforms](designs/2024-04-26-platform-exec-settings.md) | [@katre](https://github.com/katre) | Configuration |
 |   2024-03-18 | [A new home for the host platform](https://docs.google.com/document/d/1g5JAAOfLsvQKBGqzSLFp1hIYFoQsgOslsjaIGV6P7Tk/edit) | [@Wyverald](https://github.com/Wyverald) | Configurability, External Repositories |
 |   2024-02-10 | [Execution Platform Scoped Spawn Strategies](designs/2023-06-04-exec-platform-scoped-spawn-strategies.md) | [@Silic0nS0ldier](https://github.com/Silic0nS0ldier) | Configurability, Execution Strategy |
 |   2024-02-06 | [Linking on multiple platforms](https://docs.google.com/document/d/1zm1UOftT2xHQiNNxNO7XU_BOn2KrXjFlx5tl4QBVjV0/edit#heading=h.3b2hgzp0x4ct)   | [@comius](https://github.com/comius)  | C++ linking |
@@ -91,6 +90,7 @@ stateDiagram-v2
 
 | Last updated | Title                                                                                                                  | Author(s) alias                                                                    | Category              |
 | ------------ | ------------------------------------------------------------------------------------------------------------------     | ---------------------------------------------------------------------------------- | --------              |
+|   2024-05-08 | [Selectively Enabling Execution Platforms](designs/2024-04-26-platform-exec-settings.md) | [@katre](https://github.com/katre) | Configuration |
 |   2024-04-29 | [Starlark Transition Composition](designs/2024-04-16-transition-composition.md) | [@katre](https://github.com/katre) | Configuration |
 |   2023-12-06 | [`bazel mod tidy`](https://docs.google.com/document/d/13LbK_1WhA4la0eH7yISjnMvXs2cKFXD-adKPu0i0RK0/edit) | [@fmeum](https://github.com/fmeum) | External dependencies |
 |   2023-08-14 | [Platform-based flags](designs/2023-06-08-platform-based-flags.md) | [@katre](https://github.com/katre) | Platforms |

--- a/designs/2024-04-26-platform-exec-settings.md
+++ b/designs/2024-04-26-platform-exec-settings.md
@@ -1,7 +1,7 @@
 ---
 created: 2024-04-26
-last updated: 2024-04-29
-status: under review
+last updated: 2024-05-08
+status: approved
 reviewers:
   - gregestren
 title: Selectively Enabling Execution Platforms

--- a/designs/2024-04-26-platform-exec-settings.md
+++ b/designs/2024-04-26-platform-exec-settings.md
@@ -40,7 +40,7 @@ all of the settings are true for the current configuration.
 # Proposal
 
 To allow execution platforms to control whether they are active, a new attribute
-will be added, named `enabled_settings`, which will take targets that provide
+will be added, named `required_settings`, which will take targets that provide
 `ConfigMatchingProvider`. When the list of execution platforms is evaluated
 suring toolchain resolution, each execution platform will check the enabled
 settings and any that don't match the configuration will be skipped (and
@@ -60,7 +60,7 @@ platform(
     name = "remote_extra_logging",
     constraint_values = CONSTRAINT_VALUES,
     exec_properties = ...,
-    enabled_settings = [
+    required_settings = [
         ":extra_logging_enabled",
     ],
 )
@@ -75,8 +75,8 @@ platform(
 If both of these platforms are available (either via
 `register_execution_platforms` or `--extra_toolchains`), and the default for the
 `--//flag:extra_logging` flag is `False`, then the `remote` platform will be
-used because the `enabled_settings` will not match. Once the flag is set, the
-`enabled_settings` will match, and the `remote_extra_logging` platform will be available (and is
+used because the `required_settings` will not match. Once the flag is set, the
+`required_settings` will match, and the `remote_extra_logging` platform will be available (and is
 registered before the other).
 
 In this case, to be very specific, an additional `config_setting` could be

--- a/designs/2024-04-26-platform-exec-settings.md
+++ b/designs/2024-04-26-platform-exec-settings.md
@@ -46,6 +46,9 @@ suring toolchain resolution, each execution platform will check the enabled
 settings and any that don't match the configuration will be skipped (and
 reported if toolchain resolution debugging is active).
 
+This attribute has no influence on whether a platform can be used as a target
+platform (ie, with the `--platforms` flag).
+
 ## Example of platform settings
 
 ```


### PR DESCRIPTION
- Mark "Selectively Enabling Execution Platforms" as approved.
- Change attribute name to required_settings
- Added note about target platforms being out of scope